### PR TITLE
ssid's like "hello world" now working ("+"->" ")

### DIFF
--- a/microwifimanager/manager.py
+++ b/microwifimanager/manager.py
@@ -249,10 +249,10 @@ def handle_configure(client, request):
         return False
     # version 1.9 compatibility
     try:
-        ssid = match.group(1).decode("utf-8").replace("%3F", "?").replace("%21", "!")
+        ssid = match.group(1).decode("utf-8").replace("%3F", "?").replace("%21", "!").replace("+"," ")
         password = match.group(2).decode("utf-8").replace("%3F", "?").replace("%21", "!")
     except Exception:
-        ssid = match.group(1).replace("%3F", "?").replace("%21", "!")
+        ssid = match.group(1).replace("%3F", "?").replace("%21", "!").replace("+"," ")
         password = match.group(2).replace("%3F", "?").replace("%21", "!")
 
     if len(ssid) == 0:


### PR DESCRIPTION
Hi there, great job on improving WifiManager. Here I fix a Bug, the original also has. When your SSID has a space, like "hello world" it will be sent as "hello+world" which the original code does not decode and just saves - and of course then it cannot connect to this non-existent network.